### PR TITLE
feat(build): build the kernel in docker

### DIFF
--- a/bin/docker-build-kernel.sh
+++ b/bin/docker-build-kernel.sh
@@ -1,0 +1,4 @@
+docker build -t space-wars-kernel:latest --file=kernel/Dockerfile .
+containerId=$(docker create space-wars-kernel:latest)
+docker cp "$containerId":/kernel/space-wars.wasm ./client/public/space-wars.wasm 
+docker rm "$containerId"

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.23
+
+WORKDIR /kernel
+
+# Copy the Go module files
+COPY go.mod .
+COPY go.sum .
+
+# Copy the source code
+COPY js.go .
+COPY main.go .
+COPY ./kernel ./kernel
+
+# Build the WASM module
+RUN GOOS=js GOARCH=wasm go build -o space-wars.wasm
+

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,14 @@ Windows:
 powershell -Command { $env:GOOS="js"; $env:GOARCH="wasm"; go build -o ./client/public/space-wars.wasm }
 ```
 
+#### How to Build the Kernel WASM Module with Docker (without installing Go)
+
+```sh
+source ./bin/docker-build-kernel.sh
+```
+
+See [bin/docker-build-kernel.sh](bin/docker-build-kernel.sh) for more information.
+
 ### How to run the kernel tests with full coverage
 
 Linux/MacOS:


### PR DESCRIPTION
## Changes
- Allow to build the kernel without installing Go, in a docker container.

`source ./bin/docker-build-kernel.sh`